### PR TITLE
feat: make `joinWithDeep` typesafe (amazing)

### DIFF
--- a/nice-comment.ts
+++ b/nice-comment.ts
@@ -191,7 +191,7 @@ const BBNope: BBBB = "nope"
 
 export type JoinWithDeep  <Seps extends string[] | readonly string[]> = (items: JoinDeep<Seps>) => string;
 
-export const joinWithDeep = (...separators: readonly string[]): JoinWithDeep<typeof separators> =>
+export const joinWithDeep = <Seprtrs extends readonly string[]>(...separators: Seprtrs): JoinWithDeep<typeof separators> =>
 	separators
 		.slice(0, -1) // remove the last one, because we're using it in the initialization of .reduceRight
 		.reduceRight(
@@ -199,7 +199,13 @@ export const joinWithDeep = (...separators: readonly string[]): JoinWithDeep<typ
 			joinWith(separators[separators.length - 1], 0)
 		) as any // TS should infer automatically, but not yet
 
-joinWithDeep("\n", " ")(["lmao"])
+joinWithDeep("\n", " ")(["lmao", ["lmao"]])
+
+// @ts-expect-error
+joinWithDeep("\n", " ")(["lmao", ["lmao", ["NO?"]]])
+
+// @ts-expect-error
+joinWithDeep("\n", " ")(["lmao", ["lmao", ["NO?", ["YES OMG IT WORKS JUST 1 LESS ARRAY LMAO"]]]])
 
 export const joinWithIncludingFirst = (sep: string) => joinWith(sep, 1);
 export const joinWithIncludingLast = (sep: string) => joinWith(sep, 2);

--- a/nice-comment.ts
+++ b/nice-comment.ts
@@ -102,14 +102,9 @@ export function joinWith<ItemOrDeepItems extends S | DeepArray<S> = S | DeepArra
 }
 
 /**
- * joinWith(
- *   separators[0],
- *   0,
- *   ifDeepArrayThenFlattenWith(joinWith(separators[1], 0, ifDeepArrayThenFlattenWith(joinWith(separators[2], 0))))
- * );
+ * BEGIN joinWithDeep
  */
 
-// export type ArrayWithoutFirstElement<T extends any[] | readonly any[]> = T extends any[] ? T extends [infer _, ...infer RestT] ? RestT : never : never;
 export type ArrayWithoutFirstElement<T extends any[] | readonly any[]> =
 	T extends any[] | readonly any[]
 		? T extends [infer _, ...infer RestT]
@@ -119,96 +114,40 @@ export type ArrayWithoutFirstElement<T extends any[] | readonly any[]> =
 			: never
 		: never;
 
-type WO1 = ArrayWithoutFirstElement<[1,2,3]>
-type WO1R = ArrayWithoutFirstElement<readonly [1,2,3]>
+// TODO TEST TYPES
+// type WO1 = ArrayWithoutFirstElement<[1,2,3]>
+// type WO1R = ArrayWithoutFirstElement<readonly [1,2,3]>
 
 export type ArrayWithAtLeastOneElement<T = any> = [T, ...T[]];
 export type ReadonlyArrayWithAtLeastOneElement<T = any> = readonly [T, ...T[]];
 
-// type ARRR = ArrayWithoutFirstElement<[1, 2, 3, 4]>
-
-/**
- * should complete the type of `items`
- */
-// export type JoinDeep<Seps extends readonly any[]> = Seps["length"] extends 0 ? Seps | string[] : string[] | (string | JoinDeep<ArrayWithoutFirstElement<Seps>>)[];
 export type JoinDeep<Seps extends any[] | readonly any[]> = JoinDeepHelper<Seps, never>
 
-// export type JoinDeepHelper<Seps extends any[] | readonly any[], Acc > =
-// 	Seps extends { length: 0 } | never
-// 		// ? Seps | Acc
-// 		// ? Acc | (string | Acc)[]
-// 		? Acc // | Seps
-// 		// : string[] | (string | JoinDeep<string | ArrayWithoutFirstElement<Seps>>)
-// 		// : string[] | (string | JoinDeep<ArrayWithoutFirstElement<Seps>>)
-// 		// : string[] | (JoinDeepHelper<ArrayWithoutFirstElement<Seps>, (string | Acc)[] >)
-// 		// : string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, Acc | (string | Acc)[]>)[]
-// 		// : string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, Acc | (string | Acc)[]>)
-// 		// : string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)[]>) | Acc
-// 		// : string | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)[]>)[] | Acc
-// 		// : string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string | (string | Acc)[]>)[] | Acc
-// 		// : string[] | (JoinDeepHelper<any, >[] | JoinDeepHelper<>
-
-// 		: string[] | (string | JoinDeep<string | ArrayWithoutFirstElement<Seps>>)
-
-// 		// : string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, Acc>)[]
-// 		// : string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string | Acc>)
-
-// export type JoinDeepHelper<Seps extends any[] | readonly any[], Acc > =
-// 	Seps extends ArrayWithAtLeastOneElement<any> | ReadonlyArrayWithAtLeastOneElement<any>
-// 	// Seps extends { length: 0 } | never
-// 		// ? Acc // | Seps
-// 		? string[] | (string[] | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)[]>)[]
-// 		: Acc
-
+/**
+ * https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#tailrec-conditional
+ */
 export type JoinDeepHelper<Seps extends any[] | readonly any[] | never, Acc > =
 	Seps extends ArrayWithAtLeastOneElement<any> | ReadonlyArrayWithAtLeastOneElement<any>
-	// Seps extends { length: 0 } | never
-		// ? Acc // | Seps
-		// ? string[] | (string[] | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)[]>)[]
-		// ? string[] | (string[] | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)[]>)[]
-
-		// ? string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)[]>[] )[]
-		// ? string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)[]>   )[]
-
-		// ? string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)  >   )[]
-		// ? string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)  >   )[]
-		? string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>,            (string | Acc)  >   )[]
+		? | string[]
+		  | (
+			  | string
+			  | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, (string | Acc)>
+			)[]
 		: Acc
-		// : string[] | (string | Acc)[]
 
+export type DeepJoiner<Seps extends string[] | readonly string[]> = (items: JoinDeep<Seps>) => string;
 
-type O000 = JoinDeep<readonly []>
-type AAAA = JoinDeep<readonly [1]>
-type BBBB = JoinDeep<readonly [1, 2]>
-type CCCC = JoinDeep<readonly [1, 2, 3]>
-
-
-type ALMOST = JoinDeep<readonly ["\n", " "]>
-
-// type AAAA = JoinDeep<readonly [1, 2, 3, 4]>
-// type AAAA = JoinDeep<readonly [1, 2, 3, 4]>
-
-const BB: BBBB = ["lmao", ["yeet", ["kek", ["nope"]]]]
-const BBNope: BBBB = "nope"
-
-
-export type JoinWithDeep  <Seps extends string[] | readonly string[]> = (items: JoinDeep<Seps>) => string;
-
-export const joinWithDeep = <Seprtrs extends readonly string[]>(...separators: Seprtrs): JoinWithDeep<typeof separators> =>
+export const joinWithDeep = <Seprtrs extends readonly string[]>(...separators: Seprtrs): DeepJoiner<typeof separators> =>
 	separators
 		.slice(0, -1) // remove the last one, because we're using it in the initialization of .reduceRight
 		.reduceRight(
 			(composed, sep) => joinWith<ReturnType<typeof composed> | S>(sep, 0, ifDeepArrayThenFlattenWith(composed)),
 			joinWith(separators[separators.length - 1], 0)
-		) as any // TS should infer automatically, but not yet
+		) as DeepJoiner<typeof separators> // TS should infer automatically, but not yet
 
-joinWithDeep("\n", " ")(["lmao", ["lmao"]])
-
-// @ts-expect-error
-joinWithDeep("\n", " ")(["lmao", ["lmao", ["NO?"]]])
-
-// @ts-expect-error
-joinWithDeep("\n", " ")(["lmao", ["lmao", ["NO?", ["YES OMG IT WORKS JUST 1 LESS ARRAY LMAO"]]]])
+/**
+ * END joinWithDeep
+ */
 
 export const joinWithIncludingFirst = (sep: string) => joinWith(sep, 1);
 export const joinWithIncludingLast = (sep: string) => joinWith(sep, 2);

--- a/nice-comment.ts
+++ b/nice-comment.ts
@@ -180,16 +180,26 @@ type O000 = JoinDeep<readonly []>
 type AAAA = JoinDeep<readonly [1]>
 type BBBB = JoinDeep<readonly [1, 2]>
 type CCCC = JoinDeep<readonly [1, 2, 3]>
+
+
 // type AAAA = JoinDeep<readonly [1, 2, 3, 4]>
 // type AAAA = JoinDeep<readonly [1, 2, 3, 4]>
 
-export const joinWithDeep = (...separators: readonly string[]) =>
+const BB: BBBB = ["lmao", ["yeet", ["kek", ["nope"]]]]
+const BBNope: BBBB = "nope"
+
+
+export type JoinWithDeep  <Seps extends string[] | readonly string[]> = (items: JoinDeep<Seps>) => string;
+
+export const joinWithDeep = (...separators: readonly string[]): JoinWithDeep<typeof separators> =>
 	separators
 		.slice(0, -1) // remove the last one, because we're using it in the initialization of .reduceRight
 		.reduceRight(
 			(composed, sep) => joinWith<ReturnType<typeof composed> | S>(sep, 0, ifDeepArrayThenFlattenWith(composed)),
 			joinWith(separators[separators.length - 1], 0)
-		);
+		) as any // TS should infer automatically, but not yet
+
+joinWithDeep("\n", " ")(["lmao"])
 
 export const joinWithIncludingFirst = (sep: string) => joinWith(sep, 1);
 export const joinWithIncludingLast = (sep: string) => joinWith(sep, 2);

--- a/nice-comment.ts
+++ b/nice-comment.ts
@@ -171,7 +171,8 @@ export type JoinDeepHelper<Seps extends any[] | readonly any[] | never, Acc > =
 		// ? string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)[]>   )[]
 
 		// ? string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)  >   )[]
-		? string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)  >   )[]
+		// ? string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>, string[] | (string | Acc)  >   )[]
+		? string[] | (string | JoinDeepHelper<ArrayWithoutFirstElement<Seps>,            (string | Acc)  >   )[]
 		: Acc
 		// : string[] | (string | Acc)[]
 
@@ -181,6 +182,8 @@ type AAAA = JoinDeep<readonly [1]>
 type BBBB = JoinDeep<readonly [1, 2]>
 type CCCC = JoinDeep<readonly [1, 2, 3]>
 
+
+type ALMOST = JoinDeep<readonly ["\n", " "]>
 
 // type AAAA = JoinDeep<readonly [1, 2, 3, 4]>
 // type AAAA = JoinDeep<readonly [1, 2, 3, 4]>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"@types/node": "^16.11.7",
 		"jest-sucks": "0.7.1",
 		"ts-node-dev": "^1.1.8",
-		"typescript": "4.4.4"
+		"typescript": "4.5.2"
 	},
 	"keywords": [
 		"nice",

--- a/test/joinWithDeep.spec.ts
+++ b/test/joinWithDeep.spec.ts
@@ -6,9 +6,7 @@ import { joinWithDeep, toComment } from "../nice-comment";
 
 runMany([
 	[
-		"joinWithDeep",
-		// TODO TS
-		// @ts-expect-error
+		"joinWithDeep", //
 		joinWithDeep(" ", "")(["ayy", ["l", "m", "a", "o"]]),
 		`ayy lmao`,
 	],

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,10 +338,10 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-typescript@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#tailrec-conditional

in retrospective, it looks simple (or rather, simpler, than while i was iterating on it:D)
e.g. the cleanup: [`735b93b` (#1)](https://github.com/kiprasmel/nice-comment/pull/1/commits/735b93b3757cb67626a4d419a5bd1c050dd43d5f)